### PR TITLE
Add `pulise_smooth` and `custom` oscs, comment out `sin2` osc 😎

### DIFF
--- a/sources/scripts/core/oscillator.js
+++ b/sources/scripts/core/oscillator.js
@@ -10,9 +10,10 @@ var Oscillator = function()
     return 0.5 + Math.sin(value * 2 * Math.PI);
   }
 
-  this.osc_sin2 = function (value) {
-    return Math.sin(2 * Math.PI * value) * Math.sin(4 * Math.PI * value);
-  }
+  // TODO: complete sin2 - clear idea what I want, but... maths.
+  // this.osc_sin2 = function (value) {
+  //   return Math.sin(2 * Math.PI * value) * Math.sin(4 * Math.PI * value);
+  // }
 
   this.saw = function(value)
   {

--- a/sources/scripts/core/oscillator.js
+++ b/sources/scripts/core/oscillator.js
@@ -1,12 +1,9 @@
-var Oscillator = function()
-{
-  this.sin = function(value)
-  {
+var Oscillator = function () {
+  this.sin = function (value) {
     return Math.sin(value * 2 * Math.PI);
   };
 
-  this.sin_absolute = function(value)
-  {
+  this.sin_absolute = function (value) {
     return 0.5 + Math.sin(value * 2 * Math.PI);
   }
 
@@ -15,30 +12,35 @@ var Oscillator = function()
   //   return Math.sin(2 * Math.PI * value) * Math.sin(4 * Math.PI * value);
   // }
 
-  this.saw = function(value)
-  {
+  this.pulse_smooth = function (value) {
+    return 0.05 / (Math.sin(2 * Math.PI * x) * Math.tan(2 * Math.PI * x));
+  }
+
+  this.saw = function (value) {
     return 2 * (value % 1) - 1;
   };
 
-  this.saw_reverse = function(value)
-  {
+  this.saw_reverse = function (value) {
     return 1 - (2 * (x % 1));
   }
 
-  this.square = function(value)
-  {
+  this.square = function (value) {
     return (value % 1) < 0.5 ? 1 : -1;
   };
 
-  this.noise = function(value)
-  {
+  this.noise = function (value) {
     return (2 * Math.random() - 1);
   }
 
-  this.tri = function(value)
-  {
+  this.tri = function (value) {
     var v2 = (value % 1) * 4;
     if (v2 < 2) return v2 - 1;
     return 3 - v2;
   };
+
+  // generates waveform from custom text
+  // e.g.: 'sin(x)'
+  this.custom = function (value, expression) {
+    return eval('var x=value;' + expression);
+  }
 }


### PR DESCRIPTION
This PR comments out `sin2` (for now) and adds a smooth-kneed pulse wave `pulse_smooth` using trig functions, as well as a `custom` waveform for user-input equations (currently with no input scrubbing).