### PR TITLE
Bugfix: clamp values in pulse_smooth function

### DIFF
--- a/sources/scripts/core/oscillator.js
+++ b/sources/scripts/core/oscillator.js
@@ -13,7 +13,10 @@ var Oscillator = function () {
   // }
 
   this.pulse_smooth = function (value) {
-    return 0.05 / (Math.sin(2 * Math.PI * x) * Math.tan(2 * Math.PI * x));
+    var ret = 0.05 / (Math.sin(2 * Math.PI * value) * Math.tan(2 * Math.PI * value));
+    ret = ret > 1.0 ? 1.0 : ret;
+    ret = ret < -1.0 ? -1.0 : ret;
+    return ret;
   }
 
   this.saw = function (value) {


### PR DESCRIPTION
Trig functions are weird and when you use them wrong you end up with squonks that push the rendering engine to it's mathematical limit. This fix aims to clamp those infinite values to 1.0 || -1.0 as they should be.