### PR TITLE
Issue: add clamping to custom osc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ builds/
 *.wav
 
 *.wav
+.vscode/

--- a/sources/scripts/core/oscillator.js
+++ b/sources/scripts/core/oscillator.js
@@ -46,7 +46,10 @@ var Oscillator = function()
   // e.g.: 'sin(x)'
   this.custom = function(value, expression)
   {
-    return eval('var x=value;' + expression);
+    var ret = eval('var x=value;' + expression);
+    ret = ret > 1.0 ? 1.0 : ret;
+    ret = ret < -1.0 ? -1.0 : ret;
+    return ret;
   }
 
   // TODO: complete sin2 - clear idea what I want, but... maths.


### PR DESCRIPTION
- Since smoothed pulse was trying to approach infinite values I figured we'd want to add that check to custom so people didn't have any **really** strange output, instead opting for a clipped/clamped mathematical approach.

I think this will result in some interesting odd harmonics as well, so consider any abhorrent behavior from this addition a "feature" not a "bug," as the end-result the other way would end up with bugged out processing pipeline.

- also added an ignore for the `.vscode` editor dir