### PR TITLE
Fixed bug where theme files couldn't be dragged onto Marabu

### DIFF
--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -1,6 +1,6 @@
 body      { background:#000; -webkit-user-select: none;-webkit-app-region: drag; overflow: hidden; transition: background-color 500ms }
-yu        { display: block; font-family: 'input_mono_regular'; font-size:11px; line-height: 30px; vertical-align: top}
-list      { display: block }
+yu        { display: block; font-family: 'input_mono_regular'; font-size:11px; line-height: 30px; vertical-align: top; -webkit-app-region: no-drag; }
+yu:after  { display: table; content: ""; clear: both; }
 ln        { display: block;}
 ln i      { color:#999; }
 hl        { line-height: 29px; font-family: 'input_mono_medium'; display: block; border-bottom:1px solid black; }


### PR DESCRIPTION
Turns out there is inconsistent behavior between Mac OS and Windows on how -webkit-app-region: drag is handled. On Windows, this blocks window events (like 'dragover' and 'drop'), but does not on Mac. There is a workaround however, by adding -webkit-app-region: no-drag to a child-element of the element with drag, window events can be triggered on the child-element. This clearfixes the yu element giving it height, and adds no-drag to it.

Fixes #15 